### PR TITLE
Add support for basic api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 Cuppa
 
 BDD-style test framework inspired by <a href="https://mochajs.org">Mocha</a>
+
+How does it work?
+
+```java
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.mocha.Mocha.*;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.annotations.Test;
+
+@Test
+public class ListTest {
+    List<Integer> list = Arrays.asList(1, 2, 3);
+    {
+        describe("List#indexOf", () -> {
+            when("the value is not present", () -> {
+                it("returns -1", () -> {
+                    assertThat(list.indexOf(5)).isEqualTo(-1);
+                    assertThat(list.indexOf(0)).isEqualTo(-1);
+                });
+            });
+        });
+    }
+}
+```

--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -53,7 +53,7 @@
 
     <!-- CHECKSTYLE RULE -->
     <module name="FileLength">
-        <property name="max" value="500"/> <!-- TODO is this a reasonable max? -->
+        <property name="max" value="500"/>
     </module>
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>

--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <!-- SUPPRESSION FILTERS -->
+    <!--
+        Toggle Checkstyle on/off
+
+        // @Checkstyle:off
+        ... ignored
+        // @Checkstyle:on
+    -->
+    <module name="SuppressionCommentFilter">
+        <property name="offCommentFormat" value="@Checkstyle:off" />
+        <property name="onCommentFormat" value="@Checkstyle:on" />
+    </module>
+    <!--
+        Instruct Checkstyle to ignore a specific check for a whole file
+
+        // @Checkstyle:ignore AvoidNestedBlocks
+    -->
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="@Checkstyle:ignore ([\w\|]+)"/>
+        <property name="checkFormat" value="$1"/>
+        <property name="influenceFormat" value="1000000" />
+    </module>
+    <!--
+        Instruct Checkstyle to ignore next line
+
+        // @Checkstyle:ignore
+        ... ignored
+        ... checked
+    -->
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="@Checkstyle:ignore" />
+        <property name="influenceFormat" value="1" />
+    </module>
+    <!--
+        Instruct Checkstyle to ignore next N lines (-ve means previous lines)
+
+        // @Checkstyle:ignoreFor 2
+        ... ignored
+        ... ignored
+        ... checked
+    -->
+    <module name="SuppressWithNearbyCommentFilter">
+        <property name="commentFormat" value="@Checkstyle:ignoreFor (\d+)" />
+        <property name="influenceFormat" value="$1" />
+    </module>
+
+
+    <!-- CHECKSTYLE RULE -->
+    <module name="FileLength">
+        <property name="max" value="500"/> <!-- TODO is this a reasonable max? -->
+    </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="JavadocPackage"/>
+    <module name="NewlineAtEndOfFile"/>
+    <!-- Disallow trailing white space -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$" />
+        <property name="message" value="Line has trailing spaces." />
+    </module>
+    <module name="Translation"/>
+    <module name="UniqueProperties"/>
+
+    <module name="TreeWalker">
+        <!-- Required for suppressions -->
+        <module name="FileContentsHolder" />
+
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreStatic" value="false"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+        </module>
+        <module name="AnnotationUseStyle"/>
+        <module name="AnonInnerLength"/>
+        <module name="ArrayTrailingComma"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="AtclauseOrder"/>
+        <module name="AvoidEscapedUnicodeCharacters"/>
+        <!-- Disabled due to the format we like for declaring the cuppa tests --> <!-- Might be able to suppress on test code -->
+        <!--<module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true"/>
+        </module>-->
+        <module name="AvoidStarImport">
+            <property name="allowStaticMemberImports" value="true" />
+        </module>
+        <module name="BooleanExpressionComplexity"/>
+        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassFanOutComplexity"/>
+        <module name="ClassTypeParameterName"/>
+        <module name="ConstantName"/>
+        <module name="CommentsIndentation"/>
+        <module name="CovariantEquals"/>
+        <!-- To prevent needless re-ordering of imports -->
+        <module name="CustomImportOrder">
+            <property name="customImportOrderRules" value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+        </module>
+        <module name="CyclomaticComplexity"/>
+        <module name="DeclarationOrder"/>
+        <module name="DefaultComesLast"/>
+        <module name="DesignForExtension"/>
+        <module name="EmptyBlock"/>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected|ignored"/>
+            <property name="commentFormat" value="This is expected"/>
+        </module>
+        <module name="EmptyForInitializerPad"/>
+        <module name="EmptyForIteratorPad"/>
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="EqualsHashCode"/>
+        <module name="ExecutableStatementCount"/>
+        <module name="ExplicitInitialization"/>
+        <module name="FallThrough">
+            <property name="reliefPattern" value="falls? ?through"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="GenericWhitespace"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+            <property name="setterCanReturnItsClass" value="true"/>
+        </module>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="IllegalImport" />
+        <module name="IllegalInstantiation" />
+        <module name="Indentation">
+            <property name="throwsIndent" value="8" />
+            <property name="lineWrappingIndentation" value="8" />
+            <property name="forceStrictCondition" value="true" />
+        </module>
+        <module name="InnerAssignment"/>
+        <module name="InnerTypeLast"/>
+        <module name="InterfaceIsType"/>
+        <module name="InterfaceTypeParameterName"/>
+        <module name="JavaNCSS"/>
+        <module name="JavadocMethod">
+            <property name="validateThrows" value="true"/>
+            <property name="scope" value="protected"/>
+            <property name="allowUndeclaredRTE" value="true"/>
+            <property name="allowThrowsTagsForSubclasses" value="true" />
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+        </module>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="JavadocParagraph"/>
+        <!-- If Javadoc is present then it must be valid -->
+        <module name="JavadocStyle">
+            <property name="scope" value="private" />
+            <property name="checkEmptyJavadoc" value="true" />
+        </module>
+        <module name="JavadocType">
+            <property name="scope" value="protected" />
+        </module>
+        <module name="JavadocVariable">
+            <property name="scope" value="protected" />
+        </module>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="120" />
+        </module>
+        <module name="LineLength">
+            <property name="max" value="120"/>
+            <property name="ignorePattern" value="^import " />
+        </module>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MagicNumber"/>
+        <module name="MemberName"/>
+        <module name="MethodCount"/>
+        <module name="MethodLength"/>
+        <module name="MethodName"/>
+        <module name="MethodParamPad"/>
+        <module name="MethodTypeParameterName"/>
+        <module name="MissingDeprecated"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="ModifiedControlVariable"/>
+        <module name="ModifierOrder"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="MutableException"/>
+        <module name="NPathComplexity"/>
+        <module name="NeedBraces"/>
+        <!-- Encourage use of functional style instead of nesting for loops -->
+        <module name="NestedForDepth"/>
+        <module name="NestedIfDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="NestedTryDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="NoClone"/>
+        <module name="NoFinalizer"/>
+        <module name="NoLineWrap"/>
+        <!-- Allow whitespace after array initializer -->
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS" />
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OneStatementPerLine"/>
+        <module name="OperatorWrap"/>
+        <module name="OuterTypeFilename"/>
+        <module name="OuterTypeNumber"/>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="PackageAnnotation"/>
+        <module name="PackageDeclaration"/>
+        <module name="PackageName"/>
+        <module name="ParameterAssignment"/>
+        <module name="ParameterName"/>
+        <module name="ParameterNumber"/>
+        <module name="ParenPad"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <!-- Don't need to use this to enforce the header file template -->
+        <!--<module name="RegexpHeader">
+            <property name="headerFile" value="${checkstyle.header.file}" />
+            <property name="multiLines" value="1,2,3" />
+        </module>-->
+        <module name="ReturnCount">
+            <property name="max" value="3"/>
+        </module>
+        <module name="RightCurly"/>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SingleLineJavadoc"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StaticVariableName"/>
+        <module name="StringLiteralEquality"/>
+        <module name="ThrowsCount"/>
+        <module name="TodoComment">
+            <property name="format" value="(TODO)|(FIXME)"/>
+        </module>
+        <module name="TrailingComment"/>
+        <module name="TypeName"/>
+        <module name="TypecastParenPad"/>
+        <module name="UncommentedMain"/>
+        <module name="UnnecessaryParentheses"/>
+        <module name="UnusedImports"/>
+        <module name="UpperEll"/>
+        <module name="VisibilityModifier"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <!--  Javadoc should not contain author annotations -->
+        <module name="WriteTag">
+            <property name="tag" value="@author"/>
+            <property name="tagFormat" value="\S"/>
+            <!-- Ignore when not present -->
+            <property name="severity" value="ignore"/>
+            <!-- Warn when present -->
+            <property name="tagSeverity" value="error"/>
+        </module>
+    </module>
+</module>

--- a/checkstyle-test-suppressions.xml
+++ b/checkstyle-test-suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="DesignForExtension" files="/src/test/java/"/>
+    <suppress checks="JavadocPackage" files="/src/test/java/"/>
+    <suppress checks="JavadocType" files="/src/test/java/"/>
+    <suppress checks="JavadocMethod" files="/src/test/java/"/>
+    <suppress checks="JavadocVariable" files="/src/test/java/"/>
+    <suppress checks="JavadocStyle" files="/src/test/java/"/>
+    <suppress checks="MagicNumber" files="/src/test/java/"/>
+    <suppress checks="MultipleStringLiterals" files="/src/test/java/"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,60 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>2.17</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>6.13</version>
+                        </dependency>
+                    </dependencies>
+
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <!-- Enforce Checkstyle during compilation -->
+                <!-- Strictly speaking Checkstyle should be invoked as a
+                     report during site generation. However, we want
+                     to fail the build if source code does not comply with
+                     our coding guidelines, and not at a later stage when
+                     the site is generated (which may never occur for some
+                     projects).
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>checkstyle</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <configLocation>checkstyle-rules.xml</configLocation>
+                            <suppressionsLocation>checkstyle-test-suppressions.xml</suppressionsLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                        </configuration>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <reporting>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,21 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/src/main/java/org/forgerock/cuppa/Cuppa.java
+++ b/src/main/java/org/forgerock/cuppa/Cuppa.java
@@ -1,0 +1,115 @@
+package org.forgerock.cuppa;
+
+import java.util.Stack;
+
+/**
+ * Heart of the Cuppa test framework. Responsible for registering and maintaining the state of the
+ * tests to be run and running the registered tests and providing the test results back to the test
+ * runner.
+ *
+ * <p>Test class register themselves by simply being instantiated, (if using the recommended format
+ * of test classes), and the tests are run by calling {@link #runTests()}.</p>
+ *
+ * <p>Test runner implementations are responsible for calling {@link #runTests()}, which will run
+ * all the registered tests and provide the test results back to the calling test runner for
+ * output.</p>
+ */
+public final class Cuppa {
+
+    private static DescribeBlock root;
+    private static Stack<DescribeBlock> stack;
+    private static boolean runningTests;
+
+    static {
+        reset();
+    }
+
+    private Cuppa() {
+    }
+
+    /**
+     * Registers a described suite of tests to be run.
+     *
+     * @param description The description of the 'describe' block.
+     * @param function The 'describe' block.
+     */
+    public static void describe(String description, Function function) {
+        assertNotRunningTests("describe");
+        DescribeBlock currentDescribeBlock = getCurrentDescribeBlock();
+        DescribeBlock describeBlock = new DescribeBlock(description);
+        currentDescribeBlock.addDescribeBlock(describeBlock);
+        stack.push(describeBlock);
+        try {
+            function.apply();
+        } finally {
+            stack.pop();
+        }
+    }
+
+    /**
+     * Registers a 'when' block to be run.
+     *
+     * @param description The description of the 'when' block.
+     * @param function The 'when' block.
+     */
+    public static void when(String description, Function function) {
+        assertNotRunningTests("when");
+        assertNotRootDescribeBlock("when", "describe");
+        describe(description, function);
+    }
+
+    /**
+     * Registers a test function to be run.
+     *
+     * @param description The description of the test function.
+     * @param function The test function.
+     */
+    public static void it(String description, Function function) {
+        assertNotRunningTests("it");
+        assertNotRootDescribeBlock("it", "when", "describe");
+        getCurrentDescribeBlock().addTest(new TestBlock(description, function));
+    }
+
+    private static void assertNotRunningTests(String blockType) {
+        if (runningTests) {
+            throw new CuppaException(new IllegalStateException("Cannot declare new '" + blockType
+                    + "' block whilst running tests"));
+        }
+    }
+
+    private static void assertNotRootDescribeBlock(String blockType, String... allowedBlockTypes) {
+        if (getCurrentDescribeBlock().equals(root)) {
+            throw new CuppaException(new IllegalStateException("A '" + blockType + "' must be nested within a "
+                    + String.join(", ", allowedBlockTypes) + " function"));
+        }
+    }
+
+    /**
+     * Runs all the tests that have been loaded into the test framework.
+     */
+    static TestResults runTests() {
+        if (stack.size() != 1) {
+            throw new IllegalStateException("Invariant broken! The stack should never be empty.");
+        }
+        runningTests = true;
+        root.runTests();
+        return root.getTestResults();
+    }
+
+    /**
+     * For test use only.
+     *
+     * <p>Resets the test framework state.</p>
+     */
+    static void reset() {
+        runningTests = false;
+        root = new DescribeBlock("");
+        stack = new Stack<DescribeBlock>() {
+            { push(root); }
+        };
+    }
+
+    private static DescribeBlock getCurrentDescribeBlock() {
+        return stack.peek();
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/CuppaException.java
+++ b/src/main/java/org/forgerock/cuppa/CuppaException.java
@@ -1,0 +1,17 @@
+package org.forgerock.cuppa;
+
+/**
+ * Thrown to indicate that a failure whilst running Cuppa tests.
+ */
+class CuppaException extends RuntimeException {
+
+    /**
+     * Constructs a new Cuppa exception with the specified cause.
+     *
+     * @param cause The cause. (A {@code null} value is permitted, and indicates that the cause
+     *         is nonexistent or unknown.)
+     */
+    CuppaException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/DescribeBlock.java
+++ b/src/main/java/org/forgerock/cuppa/DescribeBlock.java
@@ -1,0 +1,47 @@
+package org.forgerock.cuppa;
+
+import static org.forgerock.cuppa.TestResults.EMPTY_RESULTS;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Encapsulates the 'describe' and 'when' function blocks and all nested 'describe', 'when' and
+ * test ('it') function blocks.
+ */
+class DescribeBlock {
+
+    private final String description;
+    private final List<TestBlock> testBlocks = new ArrayList<>();
+    private final List<DescribeBlock> describeBlocks = new ArrayList<>();
+
+    DescribeBlock(String description) {
+        this.description = description;
+    }
+
+    void runTests() {
+        describeBlocks.forEach(DescribeBlock::runTests);
+        testBlocks.forEach(this::runTest);
+    }
+
+    private void runTest(TestBlock testBlock) {
+        testBlock.runTest();
+    }
+
+    void addDescribeBlock(DescribeBlock describeBlock) {
+        describeBlocks.add(describeBlock);
+    }
+
+    void addTest(TestBlock testBlock) {
+        testBlocks.add(testBlock);
+    }
+
+    TestResults getTestResults() {
+        TestResults testResults = describeBlocks.stream()
+                .map(DescribeBlock::getTestResults)
+                .reduce(EMPTY_RESULTS, TestResults::combine);
+        return testBlocks.stream()
+                .map(TestBlock::getTestResults)
+                .reduce(testResults, TestResults::combine);
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/Function.java
+++ b/src/main/java/org/forgerock/cuppa/Function.java
@@ -1,0 +1,35 @@
+package org.forgerock.cuppa;
+
+import java.util.Objects;
+
+/**
+ * Represents a function that accepts no arguments argument and produces a no result.
+ *
+ * <p>This is a functional interface whose functional method is {@link #apply()}.
+ */
+@FunctionalInterface
+interface Function {
+
+    /**
+     * Runs this function.
+     */
+    void apply();
+
+    /**
+     * Returns a composed function that first applies the {@code before} function, and then applies
+     * this function. If evaluation of either function throws an exception, it is relayed to the
+     * caller of the composed function.
+     *
+     * @param before The function to apply before this function is applied.
+     * @return A composed function that first applies the {@code before} function and then
+     *     applies this function
+     * @throws NullPointerException If before function is {@code null}.
+     */
+    default Function compose(Function before) {
+        Objects.requireNonNull(before);
+        return () -> {
+            before.apply();
+            apply();
+        };
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/TestBlock.java
+++ b/src/main/java/org/forgerock/cuppa/TestBlock.java
@@ -1,0 +1,51 @@
+package org.forgerock.cuppa;
+
+import static org.forgerock.cuppa.TestResults.*;
+
+/**
+ * Encapsulates the test ('it') function block.
+ */
+class TestBlock {
+
+    private final String description;
+    private final Function function;
+    private Result result;
+
+    TestBlock(String description, Function function) {
+        this.description = description;
+        this.function = function;
+    }
+
+    void runTest() {
+        try {
+            function.apply();
+            result = Result.PASSED;
+        } catch (AssertionError e) {
+            result = Result.FAILED;
+        } catch (Exception e) {
+            result = Result.ERROR;
+        }
+    }
+
+    TestResults getTestResults() {
+        switch (result) {
+            case PASSED:
+                return PASSED_RESULT;
+            case FAILED:
+                return FAILED_RESULT;
+            case ERROR:
+                return ERROR_RESULT;
+            default:
+                throw new IllegalStateException("What!! That's not cricket!");
+        }
+    }
+
+    /**
+     * Represents the outcome state of a test run.
+     */
+    private enum Result {
+        PASSED,
+        FAILED,
+        ERROR
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/TestResults.java
+++ b/src/main/java/org/forgerock/cuppa/TestResults.java
@@ -1,0 +1,47 @@
+package org.forgerock.cuppa;
+
+/**
+ * Models the result of a one or many test executions. Multiple test results are combined by using
+ * the {@link #combine(TestResults)} method.
+ */
+final class TestResults {
+
+    static final TestResults EMPTY_RESULTS = new TestResults(0, 0, 0);
+    static final TestResults PASSED_RESULT = new TestResults(1, 0, 0);
+    static final TestResults FAILED_RESULT = new TestResults(0, 1, 0);
+    static final TestResults ERROR_RESULT = new TestResults(0, 0, 1);
+
+    private final int passedTestsCount;
+    private final int failedTestsCount;
+    private final int erroredTestsCount;
+
+    private TestResults(int passedTestsCount, int failedTestsCount, int erroredTestsCount) {
+        this.passedTestsCount = passedTestsCount;
+        this.failedTestsCount = failedTestsCount;
+        this.erroredTestsCount = erroredTestsCount;
+    }
+
+    /**
+     * Returns a new {@code TestResults} by combining this {@code TestResults} with the specified
+     * {@code TestResults}.
+     *
+     * @param results The results to combine.
+     * @return The combined test results.
+     */
+    TestResults combine(TestResults results) {
+        return new TestResults(passedTestsCount + results.passedTestsCount, failedTestsCount + results.failedTestsCount,
+                erroredTestsCount + results.erroredTestsCount);
+    }
+
+    int getPassedTestsCount() {
+        return passedTestsCount;
+    }
+
+    int getFailedTestsCount() {
+        return failedTestsCount;
+    }
+
+    int getErroredTestsCount() {
+        return erroredTestsCount;
+    }
+}

--- a/src/main/java/org/forgerock/cuppa/package-info.java
+++ b/src/main/java/org/forgerock/cuppa/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BDD-style test framework inspired by <a href="https://mochajs.org">Mocha</a>.
+ */
+package org.forgerock.cuppa;

--- a/src/test/java/org/forgerock/cuppa/CuppaTest.java
+++ b/src/test/java/org/forgerock/cuppa/CuppaTest.java
@@ -1,0 +1,307 @@
+package org.forgerock.cuppa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.forgerock.cuppa.Cuppa.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CuppaTest {
+
+    @BeforeMethod
+    public void setup() {
+        Cuppa.reset();
+    }
+
+    @Test
+    public void basicApiUsageWithSingleTestBlock() {
+
+        //Given
+        AtomicInteger hasTestFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' is run", () -> {
+                    it("runs the test", hasTestFunctionRun::incrementAndGet);
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertThat(hasTestFunctionRun.get()).isEqualTo(1);
+        assertTestResources(results, 1, 0, 0);
+    }
+
+    @Test
+    public void basicApiUsageWithMultipleDescribeWhenAndTestBlocks() {
+
+        //Given
+        List<String> testFunctionRuns = new ArrayList<>();
+        {
+            describe("basic API usage with multiple blocks", () -> {
+                when("the first 'when' block is run", () -> {
+                    it("runs the first test", () -> {
+                        testFunctionRuns.add("A");
+                    });
+                    it("runs the second test", () -> {
+                        testFunctionRuns.add("B");
+                    });
+                });
+                when("the second 'when' block is run", () -> {
+                    it("runs the third test", () -> {
+                        testFunctionRuns.add("C");
+                    });
+                    it("runs the fourth test", () -> {
+                        testFunctionRuns.add("D");
+                    });
+                });
+            });
+            describe("second basic API usage with multiple blocks", () -> {
+                when("the third 'when' block is run", () -> {
+                    it("runs the fifth test", () -> {
+                        testFunctionRuns.add("E");
+                    });
+                    it("runs the sixth test", () -> {
+                        testFunctionRuns.add("F");
+                    });
+                });
+                when("the fourth 'when' block is run", () -> {
+                    it("runs the seventh test", () -> {
+                        testFunctionRuns.add("G");
+                    });
+                    it("runs the eighth test", () -> {
+                        testFunctionRuns.add("H");
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertThat(testFunctionRuns).containsExactly("A", "B", "C", "D", "E", "F", "G", "H");
+        assertTestResources(results, 8, 0, 0);
+    }
+
+    @Test
+    public void basicApiUsageWithNestedDescribeBlock() {
+
+        //Given
+        AtomicInteger hasTestFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                describe("nested describe", () -> {
+                    when("the 'when' block is run", () -> {
+                        it("runs the test", hasTestFunctionRun::incrementAndGet);
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertThat(hasTestFunctionRun.get()).isEqualTo(1);
+        assertTestResources(results, 1, 0, 0);
+    }
+
+    @Test
+    public void basicApiUsageWithNestedDescribeInWhenBlock() {
+
+        //Given
+        AtomicInteger hasTestFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                when("the top level 'when' block is run", () -> {
+                    when("the nested 'when' block is run", () -> {
+                        it("runs the test", hasTestFunctionRun::incrementAndGet);
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertThat(hasTestFunctionRun.get()).isEqualTo(1);
+        assertTestResources(results, 1, 0, 0);
+    }
+
+    @Test
+    public void basicApiUsageShouldThrowErrorWithTopLevelWhenBlock() {
+
+        //Given
+        AtomicInteger hasWhenFunctionRun = new AtomicInteger();
+
+        //When/Then
+        assertThatThrownBy(() -> when("basic API usage", hasWhenFunctionRun::incrementAndGet))
+                .hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(hasWhenFunctionRun.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void basicApiUsageShouldThrowErrorWithTopLevelItBlock() {
+
+        //Given
+        AtomicInteger hasTestFunctionRun = new AtomicInteger();
+
+        //When/Then
+        assertThatThrownBy(() -> it("basic API usage", hasTestFunctionRun::incrementAndGet))
+                .hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(hasTestFunctionRun.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void basicApiUsageShouldReportTestErrorWithDescribeBlockNestedUnderItBlock() {
+
+        //Given
+        AtomicInteger hasInvalidUseOfDescribeFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' block is run", () -> {
+                    it("runs the test, which errors", () -> {
+                        describe("invalid use of 'describe'", hasInvalidUseOfDescribeFunctionRun::incrementAndGet);
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 0, 0, 1);
+    }
+
+    @Test
+    public void basicApiUsageShouldReportTestErrorWithWhenNestedUnderItBlock() {
+
+        //Given
+        AtomicInteger hasInvalidUseOfWhenFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' block is run", () -> {
+                    it("runs the test, which errors", () -> {
+                        when("invalid use of 'when'", hasInvalidUseOfWhenFunctionRun::incrementAndGet);
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 0, 0, 1);
+    }
+
+    @Test
+    public void basicApiUsageShouldRunTestsAfterErroredTest() {
+
+        //Given
+        AtomicInteger hasInvalidUseOfDescribeFunctionRun = new AtomicInteger();
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' is run", () -> {
+                    it("runs the first test, which fails", () -> {
+                        describe("invalid use of 'describe'", hasInvalidUseOfDescribeFunctionRun::incrementAndGet);
+                    });
+                    it("runs the second test, which passes", () -> {
+                        assertThat(true).isTrue();
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 1, 0, 1);
+    }
+
+    @Test
+    public void basicApiUsageWithSingleFailingTest() {
+
+        //Given
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' block is run", () -> {
+                    it("runs the test, which fails", () -> {
+                        assertThat(true).isFalse();
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 0, 1, 0);
+    }
+
+    @Test
+    public void basicApiUsageWithSingleErroredTest() {
+
+        //Given
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' block is run", () -> {
+                    it("runs the test, which errors", () -> {
+                        throw new RuntimeException();
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 0, 0, 1);
+    }
+
+    @Test
+    public void basicApiUsageWithPassingFailingAndErroredTests() {
+
+        //Given
+        {
+            describe("basic API usage", () -> {
+                when("the 'when' block is run", () -> {
+                    it("runs the first test, which errors", () -> {
+                        throw new RuntimeException();
+                    });
+                    it("runs the second test, which fails", () -> {
+                        assertThat(true).isFalse();
+                    });
+                    it("runs the third test, which passes", () -> {
+                        assertThat(true).isTrue();
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        assertTestResources(results, 1, 1, 1);
+    }
+
+    private void assertTestResources(TestResults results, int passed, int failed, int errored) {
+        assertThat(results.getPassedTestsCount()).isEqualTo(passed);
+        assertThat(results.getFailedTestsCount()).isEqualTo(failed);
+        assertThat(results.getErroredTestsCount()).isEqualTo(errored);
+    }
+}


### PR DESCRIPTION
Adds the API for the basic test declaration:
```java
describe('Array', function() {
    describe('#indexOf()', function () {
        it('should return -1 when the value is not present', function () {
            assert.equal(-1, [1,2,3].indexOf(5));
            assert.equal(-1, [1,2,3].indexOf(0));
        });
    });
});
```


Also checkstyle has been introduced. Most of the available checkstyle rules have been enabled with the intention of evaluating each rule when rule violations occur to determine if the rule adds value or impedes development.