### PR TITLE
Add support for before, after, beforeEach and afterEach

### DIFF
--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -124,11 +124,6 @@
         </module>
         <module name="FinalClass"/>
         <module name="GenericWhitespace"/>
-        <module name="HiddenField">
-            <property name="ignoreConstructorParameter" value="true"/>
-            <property name="ignoreSetter" value="true"/>
-            <property name="setterCanReturnItsClass" value="true"/>
-        </module>
         <module name="HideUtilityClassConstructor"/>
         <module name="IllegalImport" />
         <module name="IllegalInstantiation" />

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.9.9</version>

--- a/src/main/java/org/forgerock/cuppa/Cuppa.java
+++ b/src/main/java/org/forgerock/cuppa/Cuppa.java
@@ -1,5 +1,6 @@
 package org.forgerock.cuppa;
 
+import java.util.Optional;
 import java.util.Stack;
 
 /**
@@ -36,7 +37,7 @@ public final class Cuppa {
     public static void describe(String description, Function function) {
         assertNotRunningTests("describe");
         DescribeBlock currentDescribeBlock = getCurrentDescribeBlock();
-        DescribeBlock describeBlock = new DescribeBlock(description);
+        DescribeBlock describeBlock = new DescribeBlock(description, Optional.of(currentDescribeBlock));
         currentDescribeBlock.addDescribeBlock(describeBlock);
         stack.push(describeBlock);
         try {
@@ -56,6 +57,82 @@ public final class Cuppa {
         assertNotRunningTests("when");
         assertNotRootDescribeBlock("when", "describe");
         describe(description, function);
+    }
+
+    /**
+     * Registers a 'before' block to be run.
+     *
+     * @param function The 'before' block.
+     */
+    public static void before(Function function) {
+        before(null, function);
+    }
+
+    /**
+     * Registers a 'before' block to be run.
+     *
+     * @param description The description of the 'before' block.
+     * @param function The 'before' block.
+     */
+    public static void before(String description, Function function) {
+        getCurrentDescribeBlock().addBefore(Optional.ofNullable(description), function);
+    }
+
+    /**
+     * Registers a 'after' block to be run.
+     *
+     * @param function The 'after' block.
+     */
+    public static void after(Function function) {
+        after(null, function);
+    }
+
+    /**
+     * Registers a 'after' block to be run.
+     *
+     * @param description The description of the 'after' block.
+     * @param function The 'after' block.
+     */
+    public static void after(String description, Function function) {
+        getCurrentDescribeBlock().addAfter(Optional.ofNullable(description), function);
+    }
+
+    /**
+     * Registers a 'beforeEach' block to be run.
+     *
+     * @param function The 'beforeEach' block.
+     */
+    public static void beforeEach(Function function) {
+        beforeEach(null, function);
+    }
+
+    /**
+     * Registers a 'beforeEach' block to be run.
+     *
+     * @param description The description of the 'beforeEach' block.
+     * @param function The 'beforeEach' block.
+     */
+    public static void beforeEach(String description, Function function) {
+        getCurrentDescribeBlock().addBeforeEach(Optional.ofNullable(description), function);
+    }
+
+    /**
+     * Registers a 'afterEach' block to be run.
+     *
+     * @param function The 'afterEach' block.
+     */
+    public static void afterEach(Function function) {
+        afterEach(null, function);
+    }
+
+    /**
+     * Registers a 'afterEach' block to be run.
+     *
+     * @param description The description of the 'afterEach' block.
+     * @param function The 'afterEach' block.
+     */
+    public static void afterEach(String description, Function function) {
+        getCurrentDescribeBlock().addAfterEach(Optional.ofNullable(description), function);
     }
 
     /**
@@ -103,7 +180,7 @@ public final class Cuppa {
      */
     static void reset() {
         runningTests = false;
-        root = new DescribeBlock("");
+        root = new DescribeBlock("", Optional.empty());
         stack = new Stack<DescribeBlock>() {
             { push(root); }
         };

--- a/src/main/java/org/forgerock/cuppa/DescribeBlock.java
+++ b/src/main/java/org/forgerock/cuppa/DescribeBlock.java
@@ -4,6 +4,10 @@ import static org.forgerock.cuppa.TestResults.EMPTY_RESULTS;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.collect.Iterables;
 
 /**
  * Encapsulates the 'describe' and 'when' function blocks and all nested 'describe', 'when' and
@@ -12,24 +16,68 @@ import java.util.List;
 class DescribeBlock {
 
     private final String description;
-    private final List<TestBlock> testBlocks = new ArrayList<>();
+    private final Optional<DescribeBlock> parentDescribeBlock;
     private final List<DescribeBlock> describeBlocks = new ArrayList<>();
+    private final List<Function> beforeFunctions = new ArrayList<>();
+    private final List<Function> afterFunctions = new ArrayList<>();
+    private final List<Function> beforeEachFunctions = new ArrayList<>();
+    private final List<Function> afterEachFunctions = new ArrayList<>();
+    private final List<TestBlock> testBlocks = new ArrayList<>();
 
-    DescribeBlock(String description) {
+    DescribeBlock(String description, Optional<DescribeBlock> parentDescribeBlock) {
+        Objects.requireNonNull(description, "Block must have a description");
+        Objects.requireNonNull(parentDescribeBlock, "Block must have an optional parent block");
         this.description = description;
+        this.parentDescribeBlock = parentDescribeBlock;
     }
 
     void runTests() {
         describeBlocks.forEach(DescribeBlock::runTests);
+        beforeFunctions.forEach(Function::apply);
         testBlocks.forEach(this::runTest);
+        afterFunctions.forEach(Function::apply);
     }
 
     private void runTest(TestBlock testBlock) {
+        getBeforeEachFunctionsForTest().forEach(Function::apply);
         testBlock.runTest();
+        getAfterEachFunctionsForTest().forEach(Function::apply);
+    }
+
+    private Iterable<Function> getBeforeEachFunctionsForTest() {
+        if (parentDescribeBlock.isPresent()) {
+            return Iterables.concat(parentDescribeBlock.get().getBeforeEachFunctionsForTest(), beforeEachFunctions);
+        } else {
+            return beforeEachFunctions;
+        }
+    }
+
+    private Iterable<Function> getAfterEachFunctionsForTest() {
+        if (parentDescribeBlock.isPresent()) {
+            return Iterables.concat(afterEachFunctions, parentDescribeBlock.get().getAfterEachFunctionsForTest());
+        } else {
+            return afterEachFunctions;
+        }
     }
 
     void addDescribeBlock(DescribeBlock describeBlock) {
         describeBlocks.add(describeBlock);
+    }
+
+    void addBefore(Optional<String> description, Function function) {
+        beforeFunctions.add(function);
+    }
+
+    void addAfter(Optional<String> description, Function function) {
+        afterFunctions.add(function);
+    }
+
+    void addBeforeEach(Optional<String> description, Function function) {
+        beforeEachFunctions.add(function);
+    }
+
+    void addAfterEach(Optional<String> description, Function function) {
+        afterEachFunctions.add(function);
     }
 
     void addTest(TestBlock testBlock) {

--- a/src/test/java/org/forgerock/cuppa/CuppaTest.java
+++ b/src/test/java/org/forgerock/cuppa/CuppaTest.java
@@ -3,9 +3,7 @@ package org.forgerock.cuppa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.forgerock.cuppa.Cuppa.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -286,6 +284,134 @@ public class CuppaTest {
 
         //Then
         assertTestResources(results, 1, 1, 1);
+    }
+
+    @Test
+    public void beforeShouldRunOnceBeforeTests() {
+
+        //Given
+        Function topLevelBeforeFunction = mock(Function.class);
+        Function nestedBeforeFunction = mock(Function.class);
+        {
+            describe("before blocks", () -> {
+                before("running any tests", topLevelBeforeFunction);
+                when("the first 'when' block is run", () -> {
+                    before(nestedBeforeFunction);
+                    it("runs the first test", () -> {
+                    });
+                    it("runs the second test", () -> {
+                    });
+                });
+                when("the second 'when' block is run", () -> {
+                    it("runs the third test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        verify(topLevelBeforeFunction).apply();
+        verify(nestedBeforeFunction).apply();
+        assertTestResources(results, 3, 0, 0);
+    }
+
+    @Test
+    public void afterShouldRunOnceAfterTests() {
+
+        //Given
+        Function topLevelAfterFunction = mock(Function.class);
+        Function nestedAfterFunction = mock(Function.class);
+        {
+            describe("after blocks", () -> {
+                after("running any tests", topLevelAfterFunction);
+                when("the first 'when' block is run", () -> {
+                    after(nestedAfterFunction);
+                    it("runs the first test", () -> {
+                    });
+                    it("runs the second test", () -> {
+                    });
+                });
+                when("the second 'when' block is run", () -> {
+                    it("runs the third test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        verify(topLevelAfterFunction).apply();
+        verify(nestedAfterFunction).apply();
+        assertTestResources(results, 3, 0, 0);
+    }
+
+    @Test
+    public void beforeEachShouldRunBeforeEachTest() {
+
+        //Given
+        Function topLevelBeforeEachFunction = mock(Function.class);
+        Function nestedBeforeEachFunction = mock(Function.class);
+        {
+            describe("beforeEach blocks", () -> {
+                beforeEach("running each test", topLevelBeforeEachFunction);
+                when("the first 'when' block is run", () -> {
+                    beforeEach(nestedBeforeEachFunction);
+                    it("runs the first test", () -> {
+                    });
+                    it("runs the second test", () -> {
+                    });
+                });
+                when("the second 'when' block is run", () -> {
+                    it("runs the third test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        verify(topLevelBeforeEachFunction, times(3)).apply();
+        verify(nestedBeforeEachFunction, times(2)).apply();
+        assertTestResources(results, 3, 0, 0);
+    }
+
+    @Test
+    public void afterEachShouldRunAfterEachTest() {
+
+        //Given
+        Function topLevelAfterEachFunction = mock(Function.class);
+        Function nestedAfterEachFunction = mock(Function.class);
+        {
+            describe("afterEach blocks", () -> {
+                afterEach("running each test", topLevelAfterEachFunction);
+                when("the first 'when' block is run", () -> {
+                    afterEach(nestedAfterEachFunction);
+                    it("runs the first test", () -> {
+                    });
+                    it("runs the second test", () -> {
+                    });
+                });
+                when("the second 'when' block is run", () -> {
+                    it("runs the third test", () -> {
+                    });
+                });
+            });
+        }
+
+        //When
+        TestResults results = Cuppa.runTests();
+
+        //Then
+        verify(topLevelAfterEachFunction, times(3)).apply();
+        verify(nestedAfterEachFunction, times(2)).apply();
+        assertTestResources(results, 3, 0, 0);
     }
 
     private void assertTestResources(TestResults results, int passed, int failed, int errored) {


### PR DESCRIPTION
Adds support for before, after, beforeEach and afterEach.

```java
describe('hooks', function() {

  before(function() {
    // runs before all tests in this block
  });

  after(function() {
    // runs after all tests in this block
  });

  beforeEach(function() {
    // runs before each test in this block
  });

  afterEach(function() {
    // runs after each test in this block
  });

  // test cases
});
```