### PR TITLE
Make tests run through maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,17 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <!-- Enforce Checkstyle during compilation -->
                 <!-- Strictly speaking Checkstyle should be invoked as a
                      report during site generation. However, we want


### PR DESCRIPTION
Since renaming the test classes to *Tests.java maven has not been running the tests. This changes configures the maven surefire plugin to run tests for the following patterns:
* ***/**Test.java
* ***/**Tests.java