### PR TITLE
Fix java build warning

### DIFF
--- a/cuppa-core/src/test/java/org/forgerock/cuppa/HookTests.java
+++ b/cuppa-core/src/test/java/org/forgerock/cuppa/HookTests.java
@@ -284,7 +284,7 @@ public class HookTests {
     }
 
     private void verifiedCalledInOrder(HookFunction... functions) {
-        InOrder inOrder = inOrder(functions);
+        InOrder inOrder = inOrder((Object) functions);
         Arrays.stream(functions).forEach((f) -> {
             try {
                 inOrder.verify(f).apply();


### PR DESCRIPTION
"warning: non-varargs call of varargs method with inexact argument
type for last parameter"